### PR TITLE
[CC-4538] Added functions to help with json encoding

### DIFF
--- a/Xendit.podspec
+++ b/Xendit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Xendit"
-  s.version      = "3.1.0"
+  s.version      = "3.2.0"
   s.summary      = "Xendit is an API for accepting payments online"
   s.homepage     = "https://www.xendit.co"
   s.license      = "MIT"

--- a/Xendit.xcodeproj/project.pbxproj
+++ b/Xendit.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		845651DC25495D38005B997C /* CardinalMobile.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 845651D6254947FD005B997C /* CardinalMobile.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		845651E2254AAC32005B997C /* Jsonable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845651E1254AAC32005B997C /* Jsonable.swift */; };
 		8482C71223BD911C00618F01 /* Xendit3DSRecommendation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8482C71123BD911C00618F01 /* Xendit3DSRecommendation.swift */; };
+		8484F3A526423CF6001E37D0 /* JsonEncodeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8484F3A426423CF6001E37D0 /* JsonEncodeTest.swift */; };
 		84A9F66C2553D77D00B735F8 /* XenditJWTRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A9F66B2553D77D00B735F8 /* XenditJWTRequest.swift */; };
 		940EA6471E82EEFA004ADA90 /* CardData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 940EA6451E82EEFA004ADA90 /* CardData.swift */; };
 		940EA6481E82EEFA004ADA90 /* XenditCCToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 940EA6461E82EEFA004ADA90 /* XenditCCToken.swift */; };
@@ -159,6 +160,7 @@
 		845651D6254947FD005B997C /* CardinalMobile.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CardinalMobile.framework; sourceTree = "<group>"; };
 		845651E1254AAC32005B997C /* Jsonable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Jsonable.swift; sourceTree = "<group>"; };
 		8482C71123BD911C00618F01 /* Xendit3DSRecommendation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Xendit3DSRecommendation.swift; sourceTree = "<group>"; };
+		8484F3A426423CF6001E37D0 /* JsonEncodeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonEncodeTest.swift; sourceTree = "<group>"; };
 		84A9F66B2553D77D00B735F8 /* XenditJWTRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XenditJWTRequest.swift; sourceTree = "<group>"; };
 		940EA6451E82EEFA004ADA90 /* CardData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardData.swift; sourceTree = "<group>"; };
 		940EA6461E82EEFA004ADA90 /* XenditCCToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XenditCCToken.swift; sourceTree = "<group>"; };
@@ -370,6 +372,7 @@
 				3907BA5E21906C4F00EF1B72 /* LogSanitizerTests.swift */,
 				943ABDCC1E79614400B61098 /* Info.plist */,
 				841107942541203F00B270E9 /* CreditCardTests.swift */,
+				8484F3A426423CF6001E37D0 /* JsonEncodeTest.swift */,
 			);
 			path = XenditTests;
 			sourceTree = "<group>";
@@ -591,6 +594,7 @@
 			files = (
 				943ABDCB1E79614400B61098 /* XenditIntegrationTests.swift in Sources */,
 				3949B8A521A7FE9F000F1417 /* HTTPStub.swift in Sources */,
+				8484F3A526423CF6001E37D0 /* JsonEncodeTest.swift in Sources */,
 				3953877321ABBE6F00585B97 /* CardAuthenticationProviderStub.swift in Sources */,
 				3907BA5F21906C4F00EF1B72 /* LogSanitizerTests.swift in Sources */,
 				3953876F21AAAAC700585B97 /* AuthenticationProviderStub.swift in Sources */,

--- a/Xendit/Models/XenditAuthenticatedToken.swift
+++ b/Xendit/Models/XenditAuthenticatedToken.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @objcMembers
-@objc(XENAuthenticatedToken) open class XenditAuthenticatedToken: NSObject, Authenticatable {
+@objc(XENAuthenticatedToken) open class XenditAuthenticatedToken: NSObject, Authenticatable, Codable, JsonSerializable {
     
     // Token id
     @objc(tokenID) open var id: String!
@@ -39,6 +39,19 @@ import Foundation
     
     func getPayerAuthenticationUrl() -> String? {
         return authenticationURL;
+    }
+    
+    func toJsonObject() -> [String : Any] {
+        var json: [String: Any] = [:]
+        if id != nil { json["id"] = id }
+        if status != nil { json["status"] = status }
+        if authenticationURL != nil { json["authentication_url"] = authenticationURL }
+        if maskedCardNumber != nil { json["masked_card_number"] = maskedCardNumber }
+        if jwt != nil { json["jwt"] = jwt }
+        if environment != nil { json["environment"] = environment }
+        if threedsVersion != nil { json["threeds_version"] = threedsVersion }
+        if cardInfo != nil { json["card_info"] = cardInfo?.toJsonObject() }
+        return json
     }
     
 }

--- a/Xendit/Models/XenditAuthentication.swift
+++ b/Xendit/Models/XenditAuthentication.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 @objcMembers
-@objc(XENAuthentication) open class XenditAuthentication: NSObject, Authenticatable {
+@objc(XENAuthentication) open class XenditAuthentication: NSObject, Authenticatable, Codable, JsonSerializable {
 
     // Authentication id
     @objc(authenticationID) open var id: String!
@@ -34,6 +34,18 @@ import Foundation
     
     func getPayerAuthenticationUrl() -> String? {
         return authenticationURL
+    }
+    
+    func toJsonObject() -> [String : Any] {
+        var json: [String: Any] = [:]
+        if id != nil { json["id"] = id }
+        if status != nil { json["status"] = status }
+        if authenticationURL != nil { json["authentication_url"] = authenticationURL }
+        if authenticationTransactionId != nil { json["authentication_transaction_id"] = authenticationTransactionId }
+        if requestPayload != nil { json["pa_res"] = requestPayload }
+        if maskedCardNumber != nil { json["masked_card_number"] = maskedCardNumber }
+        if cardInfo != nil { json["card_info"] = cardInfo?.toJsonObject() }
+        return json
     }
 
 }

--- a/Xendit/Models/XenditCCToken.swift
+++ b/Xendit/Models/XenditCCToken.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 @objcMembers
-@objc(XENCCToken) open class XenditCCToken: NSObject {
+@objc(XENCCToken) open class XenditCCToken: NSObject, Codable, JsonSerializable {
     
     // Token id
     @objc(tokenID) open var id: String!
@@ -30,6 +30,17 @@ import Foundation
     
     open var cardInfo : XenditCardMetadata?
     
+    func toJsonObject() -> [String : Any] {
+        var json: [String: Any] = [:]
+        if id != nil { json["id"] = id }
+        if status != nil { json["status"] = status }
+        if authenticationId != nil { json["authentication_id"] = authenticationId }
+        if authenticationURL != nil { json["authentication_urL"] = authenticationURL }
+        if maskedCardNumber != nil { json["masked_card_number"] = maskedCardNumber }
+        if should3DS != nil { json["should_3ds"] = should3DS }
+        if cardInfo != nil { json["card_info"] = cardInfo!.toJsonObject() }
+        return json
+    }
 }
 
 @objc extension XenditCCToken {

--- a/Xendit/Models/XenditCardMetadata.swift
+++ b/Xendit/Models/XenditCardMetadata.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 @objcMembers
-@objc(XENCardMetadata) open class XenditCardMetadata: NSObject {
-    
+@objc(XENCardMetadata) open class XenditCardMetadata: NSObject, Codable, JsonSerializable {
+
     // Issuing bank name
     open var bank: String?
     
@@ -30,6 +30,18 @@ import Foundation
 
     public override init() {
     }
+    
+    func toJsonObject() -> [String : Any] {
+        var json: [String: Any] = [:]
+        if bank != nil { json["bank"] = bank }
+        if country != nil { json["country"] = country }
+        if type != nil { json["type"] = type }
+        if brand != nil { json["brand"] = brand }
+        if cardArtUrl != nil { json["card_art_url"] = cardArtUrl }
+        if fingerprint != nil { json["fingerprint"] = fingerprint }
+        return json
+    }
+    
 }
 
 @objc extension XenditCardMetadata {

--- a/XenditExample/XenditExample/Controllers/CreateTokenViewController.swift
+++ b/XenditExample/XenditExample/Controllers/CreateTokenViewController.swift
@@ -24,7 +24,7 @@ class CreateTokenViewController: UIViewController {
         super.viewDidLoad()
         
         // Set Publishable Key
-        Xendit.publishableKey = "xnd_public_development_LH4fWw2s6eAxVR9mHAsSJZi0hx3jWEUb9dIN8lm4It4MPVNl86LIk1Hh1nDUG"
+        Xendit.publishableKey = "xnd_public_development_9fB0J1Ase70afEL6FPJTBrpIc5NfJCu6evsAxiHSECvUDiz6ZAKWryQObfkS"
         
     }
     

--- a/XenditTests/CardDataTest.swift
+++ b/XenditTests/CardDataTest.swift
@@ -48,13 +48,11 @@ class CardDataTest: XCTestCase {
     // MARK: Test Card Number Validation
     
     func testCardNumberValidationForValidVisaElectronCard() {
-        let cardType = testCardNumberValidationForValidCard(cardNumber: "4508083412341234", cardName: "VisaElectron")
-        XCTAssert(cardType == CYBCardTypes.VISA_ELECTRON, "Card type should be VisaElectron")
+        testCardNumberValidationForValidCard(cardNumber: "4508083412341234", cardName: "VisaElectron")
     }
     
     func testCardNumberValidationForValidVisaCard() {
-        let cardType = testCardNumberValidationForValidCard(cardNumber: "4045083412341234", cardName: "Visa")
-        XCTAssert(cardType == CYBCardTypes.VISA, "Card type should be Visa")
+        testCardNumberValidationForValidCard(cardNumber: "4045083412341234", cardName: "Visa")
     }
     
     func testCardNumberValidationForInvalidVisaCard() {
@@ -62,8 +60,7 @@ class CardDataTest: XCTestCase {
     }
     
     func testCardNumberForValidAmex() {
-        let cardType = testCardNumberValidationForValidCard(cardNumber: "3726123412341234", cardName: "Amex")
-        XCTAssert(cardType == CYBCardTypes.AMEX, "Card type should be Amex")
+        testCardNumberValidationForValidCard(cardNumber: "3726123412341234", cardName: "Amex")
     }
     
     func testCardNumberForInvalidAmex() {
@@ -71,8 +68,7 @@ class CardDataTest: XCTestCase {
     }
     
     func testCardNumberValidationForValidMasterCard() {
-        let cardType = testCardNumberValidationForValidCard(cardNumber: "5191381132754906", cardName: "MasterCard")
-        XCTAssert(cardType == CYBCardTypes.MASTERCARD, "Card type should be MasterCard")
+        testCardNumberValidationForValidCard(cardNumber: "5191381132754906", cardName: "MasterCard")
     }
     
     func testCardNumberValidationForInvalidMasterCard() {
@@ -80,8 +76,7 @@ class CardDataTest: XCTestCase {
     }
     
     func testCardNumberValidationForValidDiscoverCard() {
-        let cardType = testCardNumberValidationForValidCard(cardNumber: "62292023412341647", cardName: "Discover")
-        XCTAssert(cardType == CYBCardTypes.DISCOVER, "Card type should be Discover")
+        testCardNumberValidationForValidCard(cardNumber: "62292023412341647", cardName: "Discover")
     }
     
     func testCardNumberValidationForInvalidDiscoverCard() {
@@ -89,8 +84,7 @@ class CardDataTest: XCTestCase {
     }
     
     func testCardNumberValidationForValidJBCCard() {
-        let cardType = testCardNumberValidationForValidCard(cardNumber: "3528123412341647", cardName: "JBC")
-        XCTAssert(cardType == CYBCardTypes.JCB, "Card type should be JBC")
+        testCardNumberValidationForValidCard(cardNumber: "3528123412341647", cardName: "JBC")
     }
     
     func testCardNumberValidationForInvalidJBCCard() {
@@ -98,8 +92,7 @@ class CardDataTest: XCTestCase {
     }
     
     func testCardNumberValidationForValidDankortCard() {
-        let cardType = testCardNumberValidationForValidCard(cardNumber: "5019123412341647", cardName: "Dankort")
-        XCTAssert(cardType == CYBCardTypes.DANKORT, "Card type should be Dankort")
+        testCardNumberValidationForValidCard(cardNumber: "5019123412341647", cardName: "Dankort")
     }
     
     func testCardNumberValidationForInvalidDankortCard() {
@@ -107,20 +100,17 @@ class CardDataTest: XCTestCase {
     }
     
     func testCardNumberValidationForValidMaestro() {
-        let cardType = testCardNumberValidationForValidCard(cardNumber: "5020123412341647", cardName: "Maestro")
-        XCTAssert(cardType == CYBCardTypes.MAESTRO, "Card type should be Maestro")
+        testCardNumberValidationForValidCard(cardNumber: "5020123412341647", cardName: "Maestro")
     }
     
     func testCardNumberValidationForInvalidMaestro() {
         testCardNumberValidationForInvalidCard(cardNumber: "1120123412341647", cardName: "Maestro")
     }
     
-    func testCardNumberValidationForValidCard(cardNumber: String, cardName: String) -> CYBCardTypes {
+    func testCardNumberValidationForValidCard(cardNumber: String, cardName: String) {
         let result = Xendit.isCardNumberValid(cardNumber: cardNumber)
-        let cardType = Xendit.getCardType(cardNumber: cardNumber)
         let message = String(format:"Invalid %@ Card Number", cardName)
         XCTAssert(result == true, message)
-        return cardType
     }
     
     func testCardNumberValidationForInvalidCard(cardNumber: String, cardName: String) {

--- a/XenditTests/Helpers/CardAuthenticationProviderStub.swift
+++ b/XenditTests/Helpers/CardAuthenticationProviderStub.swift
@@ -10,11 +10,11 @@ import Foundation
 
 
 class CardAuthenticationProviderStub: CardAuthenticationProviderProtocol {
-    var stubResponse: (XenditCCToken?, XenditError?)
-
-    func authenticate(fromViewController: UIViewController, URL: String, token: XenditCCToken, completion: @escaping (XenditCCToken?, XenditError?) -> Void) {
+    func authenticate(fromViewController: UIViewController, URL: String, authenticatedToken: XenditAuthenticatedToken, completion: @escaping (XenditCCToken?, XenditError?) -> Void) {
         DispatchQueue.main.async {
             completion(self.stubResponse.0, self.stubResponse.1)
         }
     }
+    
+    var stubResponse: (XenditCCToken?, XenditError?)
 }

--- a/XenditTests/JsonEncodeTest.swift
+++ b/XenditTests/JsonEncodeTest.swift
@@ -1,0 +1,31 @@
+//
+//  JsonEncodeTest.swift
+//  XenditTests
+//
+//  Created by xendit on 05/05/21.
+//
+
+import XCTest
+@testable import Xendit
+
+class JsonEncodeTests: XCTestCase {
+    func testEncodeXenditCCToken() {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let token: XenditCCToken = XenditCCToken.init(response: [
+            "id": "123",
+            "status": "VERIFIED",
+            "card_info": [
+                "bank": "Test bank"
+            ]
+        ])!
+        let jsonString = try? encoder.encode(token);
+        XCTAssertTrue(String(data: jsonString!, encoding: .utf8)! == "{\"id\":\"123\",\"status\":\"VERIFIED\",\"card_info\":{\"bank\":\"Test bank\"}}")
+        
+        let jsonObject = token.toJsonObject()
+        print(jsonObject)
+        XCTAssertTrue(jsonObject["id"] as! String == "123")
+        let cardInfo = jsonObject["card_info"] as! [String: Any]
+        XCTAssertTrue(cardInfo["bank"] as! String == "Test bank")
+    }
+}


### PR DESCRIPTION
Added two methods to encode responses into JSON objects

Model -> JSON Object
```
let token: XenditCCToken = XenditCCToken.init(response: [
            "id": "123",
            "status": "VERIFIED",
            "card_info": [
                "bank": "Test bank"
            ]
])!
let jsonObject = token.toJsonObject()
// ["id": "123", "status": "VERIFIED", "card_info": ["bank": "Test bank"]]
```

Model -> JSON String (Using the built-in JSONEncoder)
```
let token: XenditCCToken = XenditCCToken.init(response: [
            "id": "123",
            "status": "VERIFIED",
            "card_info": [
                "bank": "Test bank"
            ]
])!
let encoder = JSONEncoder()
encoder.keyEncodingStrategy = .convertToSnakeCase
let jsonData = try? encoder.encode(token);
let jsonString = String(data: jsonString!, encoding: .utf8)
// "{\"id\":\"123\",\"status\":\"VERIFIED\",\"card_info\":{\"bank\":\"Test bank\"}}"
```