### PR TITLE
[CC-6097] amount on tokenization validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Slack Channel: [#p-cards-product](https://xendit.slack.com/messages/p-cards-prod
 Slack Mentions: `@troops-cards`
 
 ## Running Tests
-
-1. Install [Cocoapods](https://guides.cocoapods.org/using/using-cocoapods.html) (Ruby is required)
+1. Install [Cocoapods](https://cocoapods.org/) by running `sudo gem install cocoapods`. Additionally, you can read how to setup and use it in you app [here](https://guides.cocoapods.org/using/using-cocoapods.html). (Ruby is required)
 2. In console open repository root folder and install test dependencies by running `pod install`
 3. Open `Xendit.xcworkspace`
 

--- a/Xendit.podspec
+++ b/Xendit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Xendit"
-  s.version      = "3.4.2"
+  s.version      = "3.5.0"
   s.summary      = "Xendit is an API for accepting payments online"
   s.homepage     = "https://www.xendit.co"
   s.license      = "MIT"

--- a/Xendit/Models/DTOs/XenditTokenizationRequest.swift
+++ b/Xendit/Models/DTOs/XenditTokenizationRequest.swift
@@ -10,7 +10,7 @@ import Foundation
 @objcMembers
 @objc(XenditTokenizationRequest) public class XenditTokenizationRequest: NSObject, JsonSerializable {
     
-    public var amount: NSNumber
+    public var amount: NSNumber?
     public var isSingleUse: Bool
     public var shouldAuthenticate: Bool
     public var cardData: XenditCardData
@@ -29,11 +29,13 @@ import Foundation
         self.currency = cardData.currency
     }
     
-    public init (cardData: XenditCardData, isSingleUse: Bool, shouldAuthenticate: Bool, amount: NSNumber, currency: String?) {
+    public init (cardData: XenditCardData, isSingleUse: Bool, shouldAuthenticate: Bool, amount: NSNumber?, currency: String?) {
         self.cardData = cardData
         self.isSingleUse = isSingleUse
         self.shouldAuthenticate = shouldAuthenticate
-        self.amount = amount
+        if (amount != nil) {
+            self.amount = amount
+        }
         self.currency = currency
     }
     

--- a/Xendit/XDTCards.swift
+++ b/Xendit/XDTCards.swift
@@ -230,9 +230,21 @@ public class XDTCards: CanTokenize, CanAuthenticate {
             return XenditError(errorCode: "VALIDATION_ERROR", message: "Empty publishable key")
             
         }
-        
-        guard tokenizationRequest.amount.doubleValue > 0 else {
-            return XenditError(errorCode: "VALIDATION_ERROR", message: "Amount must be a number greater than 0")
+
+        if (tokenizationRequest.isSingleUse) {
+            if (tokenizationRequest.amount != nil) {
+                guard tokenizationRequest.amount!.doubleValue > 0 else {
+                    return XenditError(errorCode: "VALIDATION_ERROR", message: "Amount must be a number greater than 0")
+                }
+            } else {
+                return XenditError(errorCode: "VALIDATION_ERROR", message: "Amount is required for single use token")
+            }
+        } else {
+            if (tokenizationRequest.amount != nil) {
+                guard tokenizationRequest.amount!.doubleValue >= 0 else {
+                    return XenditError(errorCode: "VALIDATION_ERROR", message: "Amount must not be less than 0")
+                }
+            }
         }
         
         guard CreditCard.isValidCardNumber(cardNumber: cardData.cardNumber) else {

--- a/XenditExample/XenditExample/Controllers/CreateTokenViewController.swift
+++ b/XenditExample/XenditExample/Controllers/CreateTokenViewController.swift
@@ -38,7 +38,11 @@ class CreateTokenViewController: UIViewController {
         
         let isMultipleUse = isMultipleUseSwitch.isOn
         let currency = "IDR"
-        let amount =  NSNumber(value: Double.init(amountTextField.text!)!)
+        let amountText = amountTextField.text!
+        var amount: NSNumber?
+        if (amountText != "") {
+            amount = NSNumber(value: Double.init(amountText)!)
+        }
         let tokenizationRequest = XenditTokenizationRequest.init(cardData: cardData, isSingleUse: !isMultipleUse, shouldAuthenticate: true, amount: amount, currency: currency)
         
         let billingDetails: XenditBillingDetails = XenditBillingDetails()


### PR DESCRIPTION
- Add logic to check for amount for single and multiple use token
- Make amount optional for tokenization
- Update readme file

## Test
### Single use with proper amount
![Screen Shot 2022-02-14 at 12 58 44](https://user-images.githubusercontent.com/31660411/153815419-7629374a-3a53-4056-9d53-6fa9e85e2713.png)

### Single use with 0 amount
![Screen Shot 2022-02-14 at 12 58 59](https://user-images.githubusercontent.com/31660411/153815465-d7754d56-6dac-430e-aedc-b89673a57232.png)

### Single use with no amount inputted
![Screen Shot 2022-02-14 at 13 04 53](https://user-images.githubusercontent.com/31660411/153815534-d2bbaade-e92d-4237-9e7f-2c19b0f6fa0b.png)

### Multiple use with proper amount
![Screen Shot 2022-02-14 at 12 59 42](https://user-images.githubusercontent.com/31660411/153815581-17e095a5-5342-4fec-baf3-c81e110964cc.png)

### Multiple use with 0 amount
![Screen Shot 2022-02-14 at 13 00 01](https://user-images.githubusercontent.com/31660411/153815643-9a9b3fb1-c8e2-46fe-b96f-74c759564515.png)

### Multiple use with amount less than 0
![Screen Shot 2022-02-14 at 13 00 11](https://user-images.githubusercontent.com/31660411/153815655-f6aa9a62-3b85-4bcc-b669-c99fcdd768f6.png)

### Multiple use with no amount inputted
![Screen Shot 2022-02-14 at 13 00 26](https://user-images.githubusercontent.com/31660411/153815661-74b4fc87-eca9-4975-b926-9fa4634a9ea4.png)
