### PR TITLE
Upgrade Sentry to 3.85.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,25 +1,23 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "OHHTTPStubs",
-        "repositoryURL": "https://github.com/AliSoftware/OHHTTPStubs.git",
-        "state": {
-          "branch": null,
-          "revision": "12f19662426d0434d6c330c6974d53e2eb10ecd9",
-          "version": "9.1.0"
-        }
-      },
-      {
-        "package": "Sentry",
-        "repositoryURL": "https://github.com/getsentry/sentry-cocoa.git",
-        "state": {
-          "branch": null,
-          "revision": "d277532e1c8af813981ba01f591b15bbdd735615",
-          "version": "8.8.0"
-        }
+  "pins" : [
+    {
+      "identity" : "ohhttpstubs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
+      "state" : {
+        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+        "version" : "9.1.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa.git",
+      "state" : {
+        "revision" : "e2ac1723a4a9632e291c171b6e25a0c403b0fecb",
+        "version" : "8.35.0"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
-        .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "6.2.1"),
+        .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.35.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Xendit.podspec
+++ b/Xendit.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   # Default subspec that includes the most commonly-used components
   s.subspec 'Default' do |default|
     default.dependency 'Xendit/XenditObjC'
-    default.dependency 'Sentry', '6.2.1'
+    default.dependency 'Sentry', '8.35.0'
     default.source_files = 'Sources/Xendit/**/*.swift'
   end
 

--- a/Xendit.xcodeproj/project.pbxproj
+++ b/Xendit.xcodeproj/project.pbxproj
@@ -975,8 +975,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
-				kind = exactVersion;
-				version = 6.2.1;
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.35.0;
 			};
 		};
 		648184A62BF7558D00DC5FBF /* XCRemoteSwiftPackageReference "OHHTTPStubs" */ = {

--- a/Xendit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Xendit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "946cbb6daccedf40d652a12138f78e96f660e1ad",
-        "version" : "6.2.1"
+        "revision" : "e2ac1723a4a9632e291c171b6e25a0c403b0fecb",
+        "version" : "8.35.0"
       }
     }
   ],


### PR DESCRIPTION
- Upgrade due to unable to be [build in XCode 16](https://github.com/xendit/xendit-sdk-ios-src/issues/81)