### PR TITLE
Fix memory leak on WebViewController

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Note that starting version 3.10.0, it requires minimum version of iOS 11. If you
 Add this to your Podfile.
 
 ```ruby
-pod 'Xendit', '~> 3.10.3'
+pod 'Xendit', '~> 3.10.4'
 ```
 
 **Important:** Import SDK in Objective-C project with CocoaPods integration, you can do as following

--- a/Sources/Xendit/Info.plist
+++ b/Sources/Xendit/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.10.3</string>
+	<string>3.10.4</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Xendit/WebViewController/AuthenticationWebviewController.swift
+++ b/Sources/Xendit/WebViewController/AuthenticationWebviewController.swift
@@ -76,6 +76,7 @@ class AuthenticationWebViewController: UIViewController, WKScriptMessageHandler,
 
         webView = WKWebView(frame: view.frame, configuration: webConfiguration)
         webView.navigationDelegate = self
+        webView.translatesAutoresizingMaskIntoConstraints = false
 
         view.addSubview(webView)
 
@@ -133,5 +134,15 @@ class AuthenticationWebViewController: UIViewController, WKScriptMessageHandler,
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         Log.shared.verbose("web auth: navigation error \(error)")
         authenticateCompletion(nil, XenditError(errorCode: "WEBVIEW_ERROR", message: error.localizedDescription))
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        // Remove script message handler
+        webView.configuration.userContentController.removeAllUserScripts()
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "callbackHandler")
+        // Clear any other references
+        webView.navigationDelegate = nil
+        webView = nil
     }
 }

--- a/Sources/Xendit/WebViewController/WebViewController.swift
+++ b/Sources/Xendit/WebViewController/WebViewController.swift
@@ -82,6 +82,7 @@ class WebViewController: UIViewController, WKScriptMessageHandler, WKNavigationD
         webConfiguration.userContentController = contentController
         webView = WKWebView(frame: view.frame, configuration: webConfiguration)
         webView.navigationDelegate = self
+        webView.translatesAutoresizingMaskIntoConstraints = false
 
         view.addSubview(webView)
         NSLayoutConstraint.activate([
@@ -138,5 +139,15 @@ class WebViewController: UIViewController, WKScriptMessageHandler, WKNavigationD
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         Log.shared.verbose("web auth: navigation error \(error)")
         authenticateCompletion(nil, XenditError(errorCode: "WEBVIEW_ERROR", message: error.localizedDescription))
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        // Remove script message handler
+        webView.configuration.userContentController.removeAllUserScripts()
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "callbackHandler")
+        // Clear any other references
+        webView.navigationDelegate = nil
+        webView = nil
     }
 }

--- a/Sources/Xendit/XDTApiClient.swift
+++ b/Sources/Xendit/XDTApiClient.swift
@@ -38,7 +38,7 @@ class XDTApiClient {
     internal static let CLIENT_TYPE = "SDK";
     internal static let CLIENT_API_VERSION = "2.0.0";
     internal static let CLIENT_IDENTIFIER = "Xendit iOS SDK";
-    internal static let CLIENT_SDK_VERSION = "3.10.3";
+    internal static let CLIENT_SDK_VERSION = "3.10.4";
     
     private static let WEBAPI_FLEX_BASE_URL = "https://sandbox.webapi.visa.com"
     

--- a/Xendit.podspec
+++ b/Xendit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Xendit'
-  s.version          = '3.10.3'
+  s.version          = '3.10.4'
   s.license          = 'MIT'
   s.homepage         = 'https://www.xendit.co'
   s.author           = { 'Juan Gonzalez’' => 'juan@xendit.co' }


### PR DESCRIPTION
- Add cleanup of WKWebView message handler in `viewWillDisappear`
- Remove retain cycle between WebViewController and WKUserContentController

The memory leak was caused by a retain cycle between the WebViewController and its WKUserContentController message handler. This change ensures proper cleanup when the view disappears.
