### PR TITLE
Fix: Move WKWebView cleanup to viewDidDisappear to prevent crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Note that starting version 3.10.0, it requires minimum version of iOS 11. If you
 Add this to your Podfile.
 
 ```ruby
-pod 'Xendit', '~> 3.10.5'
+pod 'Xendit', '~> 3.10.6'
 ```
 
 **Important:** Import SDK in Objective-C project with CocoaPods integration, you can do as following

--- a/Sources/Xendit/Info.plist
+++ b/Sources/Xendit/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.10.5</string>
+	<string>3.10.6</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Xendit/WebViewController/AuthenticationWebviewController.swift
+++ b/Sources/Xendit/WebViewController/AuthenticationWebviewController.swift
@@ -136,8 +136,8 @@ class AuthenticationWebViewController: UIViewController, WKScriptMessageHandler,
         authenticateCompletion(nil, XenditError(errorCode: "WEBVIEW_ERROR", message: error.localizedDescription))
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         // Remove script message handler
         webView.configuration.userContentController.removeAllUserScripts()
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "callbackHandler")

--- a/Sources/Xendit/WebViewController/WebViewController.swift
+++ b/Sources/Xendit/WebViewController/WebViewController.swift
@@ -141,8 +141,8 @@ class WebViewController: UIViewController, WKScriptMessageHandler, WKNavigationD
         authenticateCompletion(nil, XenditError(errorCode: "WEBVIEW_ERROR", message: error.localizedDescription))
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         // Remove script message handler
         webView.configuration.userContentController.removeAllUserScripts()
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "callbackHandler")

--- a/Sources/Xendit/XDTApiClient.swift
+++ b/Sources/Xendit/XDTApiClient.swift
@@ -38,7 +38,7 @@ class XDTApiClient {
     internal static let CLIENT_TYPE = "SDK";
     internal static let CLIENT_API_VERSION = "2.0.0";
     internal static let CLIENT_IDENTIFIER = "Xendit iOS SDK";
-    internal static let CLIENT_SDK_VERSION = "3.10.5";
+    internal static let CLIENT_SDK_VERSION = "3.10.6";
     
     private static let WEBAPI_FLEX_BASE_URL = "https://sandbox.webapi.visa.com"
     

--- a/Xendit.podspec
+++ b/Xendit.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name             = 'Xendit'
-  s.version          = '3.10.5'
+  s.version          = '3.10.6'
   s.license          = 'MIT'
   s.homepage         = 'https://www.xendit.co'
   s.author           = { 'Juan Gonzalez’' => 'juan@xendit.co' }
   s.social_media_url = 'https://www.facebook.com/xendit'
   s.summary          = 'Xendit is an API for accepting payments online'
   s.source           = { :git => 'https://github.com/xendit/xendit-sdk-ios-src.git', :tag => s.version }
-  s.swift_versions   = ['4', '5']
+  s.swift_versions   = ['4', '5', '6']
 
   s.platform              = :ios, '11.0'
   s.ios.deployment_target = '11.0'


### PR DESCRIPTION
- Move script message handler removal and WebView cleanup from `viewWillDisappear` to `viewDidDisappear` to ensure all `WebKit` processes have completed before resource cleanup. 
This resolves crashes that occurred when `WebKit` was still processing callbacks after the script message handler was removed prematurely.

- Will also resolve issue #99 